### PR TITLE
supply default parameters when kwargs don't exist or none

### DIFF
--- a/jwplatform/client.py
+++ b/jwplatform/client.py
@@ -61,11 +61,11 @@ class Client(object):
         self.__key = key
         self.__secret = secret
 
-        self._scheme = kwargs.pop('scheme', 'https')
-        self._host = kwargs.pop('host', 'api.jwplatform.com')
-        self._port = int(kwargs.pop('port', 80))
-        self._api_version = kwargs.pop('version', 'v1')
-        self._agent = kwargs.pop('agent', None)
+        self._scheme = kwargs.get('scheme') or 'https'
+        self._host = kwargs.get('host') or 'api.jwplatform.com'
+        self._port = int(kwargs['port']) if kwargs.get('port') else 80
+        self._api_version = kwargs.get('version') or 'v1'
+        self._agent = kwargs.get('agent')
 
         self._connection = requests.Session()
         self._connection.mount(self._scheme, RetryAdapter())

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -50,3 +50,33 @@ def test_custom_initialization():
     assert 'User-Agent' in jwp_client._connection.headers
     assert jwp_client._connection.headers['User-Agent'] == \
         'python-jwplatform/{}-{}'.format(jwplatform.__version__, AGENT)
+
+
+def test_custom_initialization_empty_kwargs():
+
+    KEY = 'api_key'
+    SECRET = 'api_secret'
+    SCHEME = None
+    HOST = None
+    PORT = None
+    API_VERSION = None
+    AGENT = None
+
+    jwp_client = jwplatform.Client(
+        KEY, SECRET,
+        scheme=SCHEME,
+        host=HOST,
+        port=PORT,
+        version=API_VERSION,
+        agent=AGENT)
+
+    assert jwp_client._Client__key == KEY
+    assert jwp_client._Client__secret == SECRET
+    assert jwp_client._scheme == 'https'
+    assert jwp_client._host == 'api.jwplatform.com'
+    assert jwp_client._port == 80
+    assert jwp_client._api_version == 'v1'
+    assert jwp_client._agent is None
+    assert 'User-Agent' in jwp_client._connection.headers
+    assert jwp_client._connection.headers['User-Agent'] == \
+        'python-jwplatform/{}'.format(jwplatform.__version__)


### PR DESCRIPTION
This fixes #19. If a kwarg value doesn't exist or its `None` we will now use the default value.