### PR TITLE
#34 Close requests.Session()

### DIFF
--- a/jwplatform/client.py
+++ b/jwplatform/client.py
@@ -100,3 +100,6 @@ class Client:
             '{}{}'.format(sbs, self.__secret).encode('utf-8')).hexdigest()
 
         return _url, _params
+
+    def __del__(self):
+        self._connection.close()


### PR DESCRIPTION
Referring to the issue I report #34 

I thought it might be good to close the requests session connection in `client.py`