### PR TITLE
fix generating signature for array parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Pycharm
+.idea/

--- a/jwplatform/v1/client.py
+++ b/jwplatform/v1/client.py
@@ -89,11 +89,22 @@ class Client:
         _params['api_kit'] = 'py-{}{}'.format(
             __version__, '-{}'.format(self._agent) if self._agent else '')
 
+        # Collect params to a list
+        # The reason using a list instead of a dict is
+        # to allow the same key multiple times with the different values in the query string
+        params_for_sbs = list()
+        for key, value in sorted(_params.items()):
+            key = quote(str(key).encode('utf-8'), safe='~')
+            if isinstance(value, list):
+               for item in value:
+                   item = quote(str(item).encode('utf-8'), safe='~')
+                   params_for_sbs.append(f"{key}={item}")
+            else:
+                value = quote(str(value).encode('utf-8'), safe='~')
+                params_for_sbs.append(f"{key}={value}")
+
         # Construct Signature Base String
-        sbs = '&'.join(['{}={}'.format(
-            quote(str(key).encode('utf-8'), safe='~'),
-            quote(str(value).encode('utf-8'), safe='~')
-        ) for key, value in sorted(_params.items())])
+        sbs = "&".join(params_for_sbs)
 
         # Add signature to the _params dict
         _params['api_signature'] = hashlib.sha1(

--- a/tests/v1/test_build_request.py
+++ b/tests/v1/test_build_request.py
@@ -66,7 +66,7 @@ def test_request_url():
         path=PATH)
 
 
-def test_signature():
+def test_signature_none_array_values_only():
 
     KEY = 'api_key'
     SECRET = 'api_secret'
@@ -103,6 +103,70 @@ def test_signature():
         quote(str(key).encode('utf-8'), safe='~'),
         quote(str(value).encode('utf-8'), safe='~')
     ) for key, value in sorted(request_params.items())])
+
+    assert params['api_signature'] == hashlib.sha1(
+        '{}{}'.format(base_str, SECRET).encode('utf-8')).hexdigest()
+
+def test_signature_with_array_values():
+
+    KEY = 'api_key'
+    SECRET = 'api_secret'
+    PATH = '/test/resource/show'
+
+    request_params = {
+        'a': 1,
+        'b': 'two',
+        'c3': 'Param 3',
+        u'❄': u'⛄',
+        't1': True,
+        'n0': None,
+        'test_array1': [1, 2, 3, 4],
+        'test_array2': ["test item1", "test item2"],
+    }
+
+    jwp_client = jwplatform.v1.Client(KEY, SECRET)
+
+    url, params = jwp_client._build_request(PATH, request_params)
+
+    assert url == 'https://api.jwplatform.com/v1{}'.format(PATH)
+    assert 'api_nonce' in params
+    assert 'api_timestamp' in params
+    assert 'api_key' in params
+    assert 'api_format' in params
+    assert 'api_kit' in params
+    assert 'api_signature' in params
+
+    request_params['api_nonce'] = params['api_nonce']
+    request_params['api_timestamp'] = params['api_timestamp']
+    request_params['api_key'] = params['api_key']
+    request_params['api_format'] = params['api_format']
+    request_params['api_kit'] = params['api_kit']
+
+    # The logic before allowing array in the query string
+    # The array in the query string will be like "key=[val1,val2]"
+    base_str = '&'.join(['{}={}'.format(
+        quote(str(key).encode('utf-8'), safe='~'),
+        quote(str(value).encode('utf-8'), safe='~')
+    ) for key, value in sorted(request_params.items())])
+
+    assert params['api_signature'] != hashlib.sha1(
+        '{}{}'.format(base_str, SECRET).encode('utf-8')).hexdigest()
+
+
+    # The array in the query string will be like "key=val1&key=val2"
+    params_for_sbs = list()
+    for key, value in sorted(request_params.items()):
+        key = quote(str(key).encode('utf-8'), safe='~')
+        if isinstance(value, list):
+            for item in value:
+                item = quote(str(item).encode('utf-8'), safe='~')
+                params_for_sbs.append(f"{key}={item}")
+        else:
+            value = quote(str(value).encode('utf-8'), safe='~')
+            params_for_sbs.append(f"{key}={value}")
+
+    # Construct Signature Base String
+    base_str = "&".join(params_for_sbs)
 
     assert params['api_signature'] == hashlib.sha1(
         '{}{}'.format(base_str, SECRET).encode('utf-8')).hexdigest()

--- a/tests/v1/test_build_request.py
+++ b/tests/v1/test_build_request.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 import time
 import hashlib
 import jwplatform
@@ -66,20 +67,46 @@ def test_request_url():
         path=PATH)
 
 
-def test_signature_none_array_values_only():
+SIGNATURE_TEST_CASES = [
+    {
+        'request_params': {
+            'a': 1,
+            'b': 'two',
+            'c3': 'Param 3',
+            u'❄': u'⛄',
+            't1': True,
+            'n0': None,
+        },
+        'expected_query_string': 'a=1&api_format=json&api_key=API_KEY_VALUE&api_kit=py-2.0.0'
+                                 '&api_nonce=API_NONCE_VALUE&api_timestamp=API_TIMESTAMP_VALUE'
+                                 '&b=two&c3=Param%203&n0=None&t1=True&%E2%9D%84=%E2%9B%84',
+    },
+    {
+        'request_params': {
+            'a': 1,
+            'b': 'two',
+            'c3': 'Param 3',
+            u'❄': u'⛄',
+            't1': True,
+            'n0': None,
+            'test_array1': [1, 2, 3, 4],
+            'test_array2': ["test item1", "test item2"],
+        },
+        'expected_query_string': 'a=1&api_format=json&api_key=API_KEY_VALUE&api_kit=py-2.0.0'
+                                 '&api_nonce=API_NONCE_VALUE&api_timestamp=API_TIMESTAMP_VALUE'
+                                 '&b=two&c3=Param%203&n0=None&t1=True&test_array1=1&test_array1=2'
+                                 '&test_array1=3&test_array1=4&test_array2=test%20item1'
+                                 '&test_array2=test%20item2&%E2%9D%84=%E2%9B%84',
+    },
+]
+@pytest.mark.parametrize('test_case', SIGNATURE_TEST_CASES)
+def test_signature_none_array_values_only(test_case):
 
     KEY = 'api_key'
     SECRET = 'api_secret'
     PATH = '/test/resource/show'
 
-    request_params = {
-        'a': 1,
-        'b': 'two',
-        'c3': 'Param 3',
-        u'❄': u'⛄',
-        't1': True,
-        'n0': None
-    }
+    request_params = test_case['request_params']
 
     jwp_client = jwplatform.v1.Client(KEY, SECRET)
 
@@ -93,80 +120,10 @@ def test_signature_none_array_values_only():
     assert 'api_kit' in params
     assert 'api_signature' in params
 
-    request_params['api_nonce'] = params['api_nonce']
-    request_params['api_timestamp'] = params['api_timestamp']
-    request_params['api_key'] = params['api_key']
-    request_params['api_format'] = params['api_format']
-    request_params['api_kit'] = params['api_kit']
-
-    base_str = '&'.join(['{}={}'.format(
-        quote(str(key).encode('utf-8'), safe='~'),
-        quote(str(value).encode('utf-8'), safe='~')
-    ) for key, value in sorted(request_params.items())])
-
-    assert params['api_signature'] == hashlib.sha1(
-        '{}{}'.format(base_str, SECRET).encode('utf-8')).hexdigest()
-
-def test_signature_with_array_values():
-
-    KEY = 'api_key'
-    SECRET = 'api_secret'
-    PATH = '/test/resource/show'
-
-    request_params = {
-        'a': 1,
-        'b': 'two',
-        'c3': 'Param 3',
-        u'❄': u'⛄',
-        't1': True,
-        'n0': None,
-        'test_array1': [1, 2, 3, 4],
-        'test_array2': ["test item1", "test item2"],
-    }
-
-    jwp_client = jwplatform.v1.Client(KEY, SECRET)
-
-    url, params = jwp_client._build_request(PATH, request_params)
-
-    assert url == 'https://api.jwplatform.com/v1{}'.format(PATH)
-    assert 'api_nonce' in params
-    assert 'api_timestamp' in params
-    assert 'api_key' in params
-    assert 'api_format' in params
-    assert 'api_kit' in params
-    assert 'api_signature' in params
-
-    request_params['api_nonce'] = params['api_nonce']
-    request_params['api_timestamp'] = params['api_timestamp']
-    request_params['api_key'] = params['api_key']
-    request_params['api_format'] = params['api_format']
-    request_params['api_kit'] = params['api_kit']
-
-    # The logic before allowing array in the query string
-    # The array in the query string will be like "key=[val1,val2]"
-    base_str = '&'.join(['{}={}'.format(
-        quote(str(key).encode('utf-8'), safe='~'),
-        quote(str(value).encode('utf-8'), safe='~')
-    ) for key, value in sorted(request_params.items())])
-
-    assert params['api_signature'] != hashlib.sha1(
-        '{}{}'.format(base_str, SECRET).encode('utf-8')).hexdigest()
-
-
-    # The array in the query string will be like "key=val1&key=val2"
-    params_for_sbs = list()
-    for key, value in sorted(request_params.items()):
-        key = quote(str(key).encode('utf-8'), safe='~')
-        if isinstance(value, list):
-            for item in value:
-                item = quote(str(item).encode('utf-8'), safe='~')
-                params_for_sbs.append(f"{key}={item}")
-        else:
-            value = quote(str(value).encode('utf-8'), safe='~')
-            params_for_sbs.append(f"{key}={value}")
-
-    # Construct Signature Base String
-    base_str = "&".join(params_for_sbs)
+    base_str = test_case['expected_query_string']
+    base_str = base_str.replace('API_KEY_VALUE', KEY)
+    base_str = base_str.replace('API_NONCE_VALUE', str(params['api_nonce']))
+    base_str = base_str.replace('API_TIMESTAMP_VALUE', str(params['api_timestamp']))
 
     assert params['api_signature'] == hashlib.sha1(
         '{}{}'.format(base_str, SECRET).encode('utf-8')).hexdigest()


### PR DESCRIPTION
**Problem**
Currently when an array is in the request body,
- `jwplatform.Client` makes a signature with a query string like `key=[1,2]`
- and the `API Gateway` redirects the request to the Media API V1 with a query string like `key=1&key=2`

The users get an invalid signature when they send an array in the body, because when Media API generates the signature with `key=1&key=2` which is different from the one that Client used `key=[1,2]`.

**Solution**
I updated the Client to generate the signature with the same query string that API Gateway would send like `key=1&key=2`